### PR TITLE
feat: agregar deshacer y rehacer #9

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -84,9 +84,12 @@ export class AppComponent {
   readonly editorTextarea = viewChild.required<ElementRef<HTMLTextAreaElement>>('editorTextarea');
   readonly lineNumber = viewChild.required<ElementRef<HTMLDivElement>>('lineNumber');
 
+  private readonly maxHistoryEntries = 100;
   private shortcutsService = inject(ShortcutsService);
   private destroyRef = inject(DestroyRef);
   private renderer = inject(Renderer2);
+  private undoStack: string[] = [];
+  private redoStack: string[] = [];
 
   previewHtml = computed<string>(() => {
     const rawHtml = marked.parse(this.inputValue(), { async: false }) as string;
@@ -182,6 +185,14 @@ export class AppComponent {
         combo: 'ctrl+alt+f',
         run: () => this.fullOrMinPreviewToggle(),
       },
+      {
+        combo: 'ctrl+z',
+        run: () => this.undo(),
+      },
+      {
+        combo: 'ctrl+shift+z',
+        run: () => this.redo(),
+      },
     ];
 
     shortcuts.push(...shortcutHeadings, ...fixedShortcuts, ...shortcutsOthers);
@@ -195,7 +206,7 @@ export class AppComponent {
 
   onInput(event: Event) {
     const input = event.target as HTMLTextAreaElement;
-    this.inputValue.set(input.value);
+    this.updateEditorValue(input.value);
     this.refreshSearchSelection();
   }
 
@@ -247,7 +258,7 @@ export class AppComponent {
     const after = this.inputValue().slice(end);
     const newValue = before + text + after;
 
-    this.inputValue.set(newValue);
+    this.updateEditorValue(newValue);
     this.selectedText.set('');
 
     if (textarea) {
@@ -313,7 +324,7 @@ export class AppComponent {
         newValue = this.inputValue() + tag;
         break;
     }
-    this.inputValue.set(newValue);
+    this.updateEditorValue(newValue);
     this.selectedText.set('');
   }
 
@@ -331,7 +342,31 @@ export class AppComponent {
     const newValue = before + text + after;
 
     this.selectedText.set('');
-    return this.inputValue.set(newValue);
+    this.updateEditorValue(newValue);
+  }
+
+  undo() {
+    const previousValue = this.undoStack.pop();
+
+    if (previousValue === undefined) {
+      return;
+    }
+
+    this.redoStack.push(this.inputValue());
+    this.inputValue.set(previousValue);
+    this.refreshSearchSelection();
+  }
+
+  redo() {
+    const nextValue = this.redoStack.pop();
+
+    if (nextValue === undefined) {
+      return;
+    }
+
+    this.undoStack.push(this.inputValue());
+    this.inputValue.set(nextValue);
+    this.refreshSearchSelection();
   }
 
   hideOrShowPreviewToggle() {
@@ -381,6 +416,22 @@ export class AppComponent {
     const nextIndex = Math.min(Math.max(this.activeMatchIndex(), 0), matches.length - 1);
 
     this.selectMatch(nextIndex, true);
+  }
+
+  private updateEditorValue(nextValue: string) {
+    const currentValue = this.inputValue();
+
+    if (nextValue === currentValue) {
+      return;
+    }
+
+    this.undoStack.push(currentValue);
+    if (this.undoStack.length > this.maxHistoryEntries) {
+      this.undoStack.shift();
+    }
+
+    this.redoStack = [];
+    this.inputValue.set(nextValue);
   }
 
   private selectMatch(matchIndex: number, preserveFocus = false) {

--- a/src/app/services/shortcuts.service.ts
+++ b/src/app/services/shortcuts.service.ts
@@ -16,7 +16,12 @@ export class ShortcutsService {
 
     const isCtrl = event.ctrlKey || event.metaKey;
 
-    const combo = [isCtrl && 'ctrl', event.altKey && 'alt', event.key.toLowerCase()]
+    const combo = [
+      isCtrl && 'ctrl',
+      event.altKey && 'alt',
+      event.shiftKey && 'shift',
+      event.key.toLowerCase(),
+    ]
       .filter(Boolean)
       .join('+');
 

--- a/tests/app/app.component.spec.ts
+++ b/tests/app/app.component.spec.ts
@@ -54,6 +54,34 @@ describe('AppComponent', () => {
     expect(component.inputValue()).toBe('hello');
   });
 
+  it('should undo and redo editor changes', () => {
+    component.inputValue.set('hello');
+
+    component.onInput({ target: { value: 'hello world' } } as unknown as Event);
+    component.onInput({ target: { value: 'hello world!!!' } } as unknown as Event);
+
+    component.undo();
+
+    expect(component.inputValue()).toBe('hello world');
+
+    component.undo();
+
+    expect(component.inputValue()).toBe('hello');
+
+    component.redo();
+
+    expect(component.inputValue()).toBe('hello world');
+  });
+
+  it('should register undo and redo shortcuts on init', () => {
+    expect(shortcutsService.register).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ combo: 'ctrl+z' }),
+        expect.objectContaining({ combo: 'ctrl+shift+z' }),
+      ]),
+    );
+  });
+
   it('should append element when no text is selected', () => {
     component.inputValue.set('hello');
     component.selectedText.set('');

--- a/tests/app/services/shortcuts.service.spec.ts
+++ b/tests/app/services/shortcuts.service.spec.ts
@@ -91,4 +91,20 @@ describe('ShortcutsService (Jest)', () => {
     expect(handled).toBe(false);
     expect(action).not.toHaveBeenCalled();
   });
+
+  it('should support shortcuts with shift modifier', () => {
+    const action = jest.fn();
+
+    service.register([{ combo: 'ctrl+shift+z', run: action }]);
+
+    const event = createKeyboardEvent('z', {
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    const handled = service.handle(event);
+
+    expect(handled).toBe(true);
+    expect(action).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Cambios
- Agregado historial local del editor con limite de 100 cambios
- Incorporados atajos ctrl+z y ctrl+shift+z para deshacer y rehacer
- Actualizado shortcuts service para soportar combinaciones con shift
- Añadidas pruebas para historial del editor y nuevos atajos

